### PR TITLE
Update static file copying to match current JSdoc default template im…

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -395,18 +395,25 @@ exports.publish = function(taffyData, opts, tutorials) {
     var staticFilePaths;
     var staticFileFilter;
     var staticFileScanner;
-    if (conf['default'].staticFiles) {
-        staticFilePaths = conf['default'].staticFiles.paths || [];
-        staticFileFilter = new (require('jsdoc/src/filter')).Filter(conf['default'].staticFiles);
-        staticFileScanner = new (require('jsdoc/src/scanner')).Scanner();
+    if (conf.default.staticFiles) {
+        // The canonical property name is `include`. We accept `paths` for backwards compatibility
+        // with a bug in JSDoc 3.2.x.
+        staticFilePaths = conf.default.staticFiles.include ||
+            conf.default.staticFiles.paths ||
+            [];
+        staticFileFilter = new (require('jsdoc/src/filter').Filter)(conf.default.staticFiles);
+        staticFileScanner = new (require('jsdoc/src/scanner').Scanner)();
 
-        staticFilePaths.forEach(function(filePath) {
-            var extraStaticFiles = staticFileScanner.scan([filePath], 10, staticFileFilter);
+        staticFilePaths.forEach(filePath => {
+            let extraStaticFiles;
 
-            extraStaticFiles.forEach(function(fileName) {
-                var sourcePath = fs.statSync(filePath).isDirectory() ? filePath :
-                    path.dirname(filePath);
-                var toDir = fs.toDir( fileName.replace(sourcePath, outdir) );
+            filePath = path.resolve(env.pwd, filePath);
+            extraStaticFiles = staticFileScanner.scan([filePath], 10, staticFileFilter);
+
+            extraStaticFiles.forEach(fileName => {
+                const sourcePath = fs.toDir(filePath);
+                const toDir = fs.toDir( fileName.replace(sourcePath, outdir) );
+
                 fs.mkPath(toDir);
                 fs.copyFileSync(fileName, toDir);
             });


### PR DESCRIPTION
…plementation.

Makes static file copying match the documented behaviour.

And more importantly, fixes bug where if the directory separator used in
the config didn't match the directory separator of the OS it would attempt
to copy the static files over themselves, and due to the custom copyFileSync
implementation in jsdoc they would get clobbered to a 0 byte file.