### PR TITLE
Change tutorial navigation.

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -42,6 +42,12 @@ $(function () {
     var $currentItem = $nav.find('.item[data-name*="' + filename + '"]:eq(0)');
 
     if ($currentItem.length) {
+        // if a child then show the top level parent and highlight the
+        // current item.
+        if ($currentItem.parents('.children').length) {
+            $currentItem.addClass('current');
+            $currentItem = $currentItem.parents('ul.list>li.item');
+        }
         $currentItem
             .remove()
             .prependTo($list)

--- a/src/styles/navigation.less
+++ b/src/styles/navigation.less
@@ -77,10 +77,6 @@
         bottom: 0;
     }
 
-    li:not(.current) > ul.parent {
-      display:none !important;
-    }
-
     li.item {
         margin-bottom: 8px;
         padding-bottom: 8px;
@@ -152,6 +148,9 @@
         li.item {
             border-bottom: none;
             padding-bottom: 0px;
+        }
+        li.current {
+            font-weight: bold;
         }
     }
 

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -114,13 +114,6 @@ var self = this;
             </ul>
             <?js 
             }
-            if (item.parent) {
-            ?>
-            <ul class="parent itemMembers">
-            <li><span class="subtitle">&lt;&lt;&lt; </span><span class="title"><?js= self.tutoriallink(item.parent.longname) ?></span></li>
-            </ul>
-            <?js
-            }
             if (item.children) {
             ?>
             <ul class="children itemMembers">


### PR DESCRIPTION
When in child tutorials the top level tutorial is shown in navigation and
all children. The currently open tutorial is displayed in bold. Allows for
easier navigation than previously where only a 'parent' link was available.